### PR TITLE
Fixes Tribute.podspec

### DIFF
--- a/Tribute.podspec
+++ b/Tribute.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'Tribute'
   s.version = '0.1'
-  s.summary = 'Programmatic creation of NSAttributedString doesn't have to be a pain'
+  s.summary = 'Programmatic creation of NSAttributedString does not have to be a pain'
   s.homepage = 'https://github.com/zats/Tribute'
   s.authors = { 'Sash Zats' => 'sash@zats.io' }
   s.source = { :git => 'https://github.com/zats/Tribute.git', :tag => s.version }


### PR DESCRIPTION
Removes extraneous single quote (fixes pod spec parsing error: [!] Unable to load a podspec from `Tribute.podspec`, skipping)
